### PR TITLE
Create SuspiciousOAuthOfflineAccess.yaml

### DIFF
--- a/Detections/AuditLogs/SuspiciousOAuthOfflineAccess.yaml
+++ b/Detections/AuditLogs/SuspiciousOAuthOfflineAccess.yaml
@@ -1,0 +1,54 @@
+id: 3533f74c-9207-4047-96e2-0eb9383be587
+name: Suspicious application consent for offline access
+description: |
+  'This will alert when a user consents to provide a previously-unknown Azure application with offline access via OAuth.
+  Offline access will provide the Azure App with access to the listed resources without requiring two-factor authentication.
+  Consent to applications with offline access and read capabilities should be rare, especially as the knownApplications list is expanded. Public contributions to expand this filter are welcome!
+  For further information on AuditLogs please see https://docs.microsoft.com/azure/active-directory/reports-monitoring/reference-audit-activities.'
+severity: Low
+requiredDataConnectors:
+  - connectorId: AzureActiveDirectory
+    dataTypes:
+      - AuditLogs
+queryFrequency: 1d
+queryPeriod: 14d
+triggerOperator: gt
+triggerThreshold: 0
+tactics:
+  - CredentialAccess
+relevantTechniques:
+  - T1528
+query: |
+Proposing modification:
+  let timeframe = 14d;
+  AuditLogs
+  | where TimeGenerated > ago(timeframe)
+  | where LoggedByService == "Core Directory"
+  | where Category == "ApplicationManagement"
+  | where OperationName == "Consent to application"
+  | where Result != "failure"
+  | where TargetResources has "offline"
+  | extend AppDisplayName = tostring(TargetResources.[0].displayName)
+  | extend AppClientId = tolower(tostring(TargetResources.[0].id))
+  | where AppClientId !in ((externaldata(knownAppClientId:string, knownAppDisplayName: string)[@"https://gist.githubusercontent.com/itsreallynick/91337579b503df33192e9a69997c5d63/raw/451cfd4a28f0b810ff7a78b7eb81fb59b8cf77d0/carr_oauth.csv"] with (format="csv")))
+  | parse TargetResources.[0].modifiedProperties with * "ConsentType: " GrantConsentType ", Scope: " GrantScopes "]" *
+  | where GrantScopes contains "Files.Read" or GrantScopes contains "Mail.Read" or GrantScopes contains "Notes.Read" or GrantScopes contains "ChannelMessage.Read" or GrantScopes contains "Chat.Read" or GrantScopes contains "TeamsActivity.Read" or GrantScopes contains "Group.Read" or GrantScopes contains "EWS.AccessAsUser.All" or GrantScopes contains "EAS.AccessAsUser.All "
+  | where GrantConsentType != "AllPrincipals" // NOTE: we are ignoring if OAuth application was granted to all users via an admin - but admin due diligence should be audited occasionally
+  | where GrantScopes contains "offline_access"
+  | extend GrantIpAddress = iff(isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).ipAddress)),
+  tostring(parse_json(tostring(InitiatedBy.user)).ipAddress), tostring(parse_json(tostring(InitiatedBy.app)).ipAddress))
+  | extend GrantInitiatedBy = iff(isnotempty(tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName)),
+  tostring(parse_json(tostring(InitiatedBy.user)).userPrincipalName), tostring(parse_json(tostring(InitiatedBy.app)).displayName))
+  | mv-expand AdditionalDetails
+  | where tostring(parse_json(AdditionalDetails).key) == "User-Agent"
+  | extend GrantUserAgent = tostring(parse_json(AdditionalDetails).value)
+  | join kind = leftouter (AuditLogs
+  | where TimeGenerated > timeframe
+  | where LoggedByService == "Core Directory"
+  | where Category == "ApplicationManagement"
+  | where OperationName == "Add service principal"
+  | extend AppClientId = tostring(TargetResources[0].id)
+  | extend AppReplyURLs = parse_json(tostring(parse_json(tostring(TargetResources[0].modifiedProperties))[1].newValue))
+  )
+  on AppClientId
+  | project TimeGenerated, GrantConsentType, GrantScopes, GrantInitiatedBy, AppDisplayName, AppReplyURLs, GrantIpAddress, GrantUserAgent, AppClientId, OperationName


### PR DESCRIPTION
Creating pull request to add this query.
Need to move the externalData lookup to the "Sample Data" area of GitHub (https://raw.githubusercontent.com/itsreallynick/Azure-Sentinel/038be7798bb116a879972b50f0a498a11ed7c41c/Sample%20Data/Feeds/Microsoft.OAuth.KnownApplications.csv), will edit before publication

Fixes #

## Proposed Changes
  - submitting initial OAuth detection
  - adding OAuth appID whitelist CSV to Azure-Sentinel GitHub's sample-data
  - this will be peer-reviewed by MSTIC RnD